### PR TITLE
Fixed wrong license in pom.xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ publishing {
                 url = "https://www.github.com/nifty10m/yangying"
                 licenses {
                     license {
-                        name = "The Apache License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                        name = "MIT License"
+                        url = "http://www.opensource.org/licenses/mit-license.php"
                     }
                 }
                 developers {


### PR DESCRIPTION
pom.xml did not respect the MIT license of the project which is
present on the github page.