### PR TITLE
Fixed bug and moved check for comparison to then block

### DIFF
--- a/src/test/groovy/de/xm/yangying/FileSnapshotsIntegrationTest.groovy
+++ b/src/test/groovy/de/xm/yangying/FileSnapshotsIntegrationTest.groovy
@@ -26,25 +26,22 @@ class FileSnapshotsIntegrationTest extends Specification {
   }
 
   def "Check comparison of objects"() {
-    given:
-      def sample = new Sample(name: "Donald", number: 121)
     when:
-      FileSnapshots.snapshot(sample, Comparisons.OBJECT_AS_JSON) == FileSnapshots.current(sample, Comparisons.OBJECT_AS_JSON)
+      def sample = new Sample(name: "Daisy", number: 121)
     then:
-      noExceptionThrown()
+      FileSnapshots.snapshot(sample, Comparisons.OBJECT_AS_JSON) == FileSnapshots.current(sample, Comparisons.OBJECT_AS_JSON)
   }
 
   def "Check comparison of stream"() {
-    given:
+    when:
       def sample = new StreamSample(name: "Donald",
         number: 121,
         stream: new ByteArrayInputStream("Hello World".bytes),
         url: new URL("http://www.google.com"),
         random: 2.7182818284590)
-    when:
+    then:
       def snapshot = FileSnapshots.snapshot(sample, Comparisons.OBJECT_AS_JSON)
       def current = FileSnapshots.current(sample, Comparisons.OBJECT_AS_JSON)
-    then:
       snapshot == current
   }
 

--- a/src/test/resources/de/xm/yangying/file-snapshots-integration-test/snapshots/check-comparison-of-objects-with-id-and-createddate.json
+++ b/src/test/resources/de/xm/yangying/file-snapshots-integration-test/snapshots/check-comparison-of-objects-with-id-and-createddate.json
@@ -1,6 +1,0 @@
-{
-  "createdAt": "2019-03-22T14:19:34+0000",
-  "id": "bed0196c-7771-42bf-af6a-9afb0a6363bd",
-  "name": "Donald",
-  "number": 121
-}

--- a/src/test/resources/de/xm/yangying/file-snapshots-integration-test/snapshots/check-comparison-of-objects.json
+++ b/src/test/resources/de/xm/yangying/file-snapshots-integration-test/snapshots/check-comparison-of-objects.json
@@ -1,4 +1,4 @@
 {
-  "name": "Donald",
+  "name": "Daisy",
   "number": 121
 }

--- a/src/test/resources/de/xm/yangying/file-snapshots-integration-test/snapshots/multiple-test-in-one-method-should-be-possible-2.json
+++ b/src/test/resources/de/xm/yangying/file-snapshots-integration-test/snapshots/multiple-test-in-one-method-should-be-possible-2.json
@@ -1,4 +1,4 @@
 {
-  "name": "Pluto",
-  "number": 42
+    "name": "Pluto",
+    "number": 42
 }

--- a/src/test/resources/de/xm/yangying/file-snapshots-integration-test/snapshots/multiple-test-in-one-method-should-be-possible.json
+++ b/src/test/resources/de/xm/yangying/file-snapshots-integration-test/snapshots/multiple-test-in-one-method-should-be-possible.json
@@ -1,4 +1,4 @@
 {
-  "name": "Donald",
-  "number": 121
+    "name": "Donald",
+    "number": 121
 }


### PR DESCRIPTION
Original test did just check if no exception was thrown but not if
objects are equals.
Includes updates of snapshots in a way they would be generated with
latest version.