### PR TITLE
The output of a comparison should work if the method returns boolean

### DIFF
--- a/src/main/groovy/de/xm/yangying/FileSnapshots.groovy
+++ b/src/main/groovy/de/xm/yangying/FileSnapshots.groovy
@@ -29,11 +29,10 @@ class FileSnapshots {
     "true".equalsIgnoreCase(System.getenv("SPOCK_UPDATE"))
   }
 
-  static def assertSnapshot(def sample, Comparison comparison) {
+  static void assertSnapshot(def sample, Comparison comparison) {
     def ying = snapshot(sample, comparison)
     def yang = current(sample, comparison)
     assert ying == yang
-    return ying == yang
   }
 
   static def snapshot(def content, Comparison comparison) {


### PR DESCRIPTION
If returning a non void method the assert result is not printed on
the console.