### PR TITLE
Added a info about the outdate yangying package

### DIFF
--- a/src/main/groovy/de/xm/yangying/FeatureNameExtension.groovy
+++ b/src/main/groovy/de/xm/yangying/FeatureNameExtension.groovy
@@ -28,7 +28,8 @@ class FeatureNameExtension implements IGlobalExtension {
   }
 
   void start() {
-
+    LOG.info("This is an outdate release of yangying and is discontinued. Please use yangyin which is the latest version of the lib")
+    LOG.info("Just replace the package yangying with the package yangyin in your project")
   }
 
   @Override


### PR DESCRIPTION
The common spelling should be yangyin and not yangying, so
package and identiefiers have be changed using the new spelling.